### PR TITLE
Configure namespaces build service

### DIFF
--- a/build-service.py
+++ b/build-service.py
@@ -180,10 +180,9 @@ def build_repo(repo_dir, branch, deploy_conf, service_conf):
     # return label of build image
     return image_name
 
+
 # create a new namespace specified in the deployment script and the namespace is not already in the system.
 # otherwise, if not specified, use default as namespace
-
-
 def create_namespace(kubernetes_api, deploy_conf):
 
     if "namespace" not in deploy_conf["metadata"]:
@@ -323,7 +322,10 @@ def restart_request(image_name):
         kubernetes_api = kubernetes.client.AppsV1Api()
         try:
             kubernetes_api.patch_namespaced_deployment(
-                name=image_name, namespace=deploy_conf["metadata"]["namespace"], body=deploy_conf)
+                name=image_name,
+                namespace=deploy_conf["metadata"]["namespace"],
+                body=deploy_conf,
+            )
         except ApiException as e:
             logging.error(f"failed to restart: {e}")
             return {"err": f"Failed to restart: {e}"}, 500
@@ -367,7 +369,10 @@ if __name__ == "__main__":
             if args["--restart"]:
                 image_name = args["--restart"]
                 kubernetes_api.patch_namespaced_deployment(
-                    name=image_name, namespace=(deploy_conf["metadata"]["namespace"]), body=deploy_conf)
+                    name=image_name,
+                    namespace=deploy_conf["metadata"]["namespace"],
+                    body=deploy_conf,
+                )
                 logging.info(f"Successfully restarted '{image_name}'")
 
             elif args["--delete"]:

--- a/build-service.py
+++ b/build-service.py
@@ -186,11 +186,11 @@ def build_repo(repo_dir, branch, deploy_conf, service_conf):
 
 def create_namespace(kubernetes_api, deploy_conf):
 
-    if ("namespace" not in deploy_conf["metadata"]):
+    if "namespace" not in deploy_conf["metadata"]:
         # namespace is not specified in deplyoment config, just say the that namespace is default
         deploy_conf["metadata"]["namespace"] = "default"
         return
-    elif (deploy_conf["metadata"]["namespace"] == "default"):
+    elif deploy_conf["metadata"]["namespace"] == "default":
         # do nothing
         return
 
@@ -198,10 +198,12 @@ def create_namespace(kubernetes_api, deploy_conf):
     try:
         namespaces = kubernetes_api.list_namespaced_deployment(ns)
         # logging.debug(namespaces.items)
-        if (len(namespaces.items) > 0):
+        if len(namespaces.items) > 0:
             logging.debug(f"deployments found for {ns}. Don't need to make namespace")
         else:
-            logging.debug("no deployments found for namespace, time to make another one")
+            logging.debug(
+                "no deployments found for namespace, time to make another one"
+            )
             testclient = dynamic.DynamicClient(
                 api_client.ApiClient(configuration=config.load_kube_config())
             )
@@ -321,10 +323,7 @@ def restart_request(image_name):
         kubernetes_api = kubernetes.client.AppsV1Api()
         try:
             kubernetes_api.patch_namespaced_deployment(
-                name=image_name,
-                namespace=deploy_conf["metadata"]["namespace"],
-                body=deploy_conf
-            )
+                name=image_name, namespace=deploy_conf["metadata"]["namespace"], body=deploy_conf)
         except ApiException as e:
             logging.error(f"failed to restart: {e}")
             return {"err": f"Failed to restart: {e}"}, 500
@@ -368,10 +367,7 @@ if __name__ == "__main__":
             if args["--restart"]:
                 image_name = args["--restart"]
                 kubernetes_api.patch_namespaced_deployment(
-                    name=image_name,
-                    namespace=(deploy_conf["metadata"]["namespace"]),
-                    body=deploy_conf
-                )
+                    name=image_name, namespace=(deploy_conf["metadata"]["namespace"]), body=deploy_conf)
                 logging.info(f"Successfully restarted '{image_name}'")
 
             elif args["--delete"]:

--- a/build-service.py
+++ b/build-service.py
@@ -186,7 +186,7 @@ def build_repo(repo_dir, branch, deploy_conf, service_conf):
 
 def create_namespace(kubernetes_api, deploy_conf):
 
-    if (not "namespace" in deploy_conf["metadata"]):
+    if ("namespace" not in deploy_conf["metadata"]):
         # namespace is not specified in deplyoment config, just say the that namespace is default
         deploy_conf["metadata"]["namespace"] = "default"
         return
@@ -201,7 +201,7 @@ def create_namespace(kubernetes_api, deploy_conf):
         if (len(namespaces.items) > 0):
             logging.debug(f"deployments found for {ns}. Don't need to make namespace")
         else:
-            logging.debug(f"no deployments found for namespace, time to make another one")
+            logging.debug("no deployments found for namespace, time to make another one")
             testclient = dynamic.DynamicClient(
                 api_client.ApiClient(configuration=config.load_kube_config())
             )
@@ -209,7 +209,10 @@ def create_namespace(kubernetes_api, deploy_conf):
             namespace_manifest = {
                 "apiVersion": "v1",
                 "kind": "Namespace",
-                "metadata": {"name": ns, "resourceversion": "v1"},
+                "metadata": {
+                    "name": ns, 
+                    "resourceversion": "v1"
+                    },
             }
             namespace_api.create(body=namespace_manifest)
             logging.debug(f"created a new namespace :{namespace_manifest}")
@@ -366,14 +369,14 @@ if __name__ == "__main__":
             if args["--restart"]:
                 image_name = args["--restart"]
                 kubernetes_api.patch_namespaced_deployment(
-                    name=image_name, namespace=deploy_conf["metadata"]["namespace"], body=deploy_conf
+                    name=image_name, namespace=(deploy_conf["metadata"]["namespace"]), body=deploy_conf
                 )
                 logging.info(f"Successfully restarted '{image_name}'")
 
             elif args["--delete"]:
                 image_name = args["--delete"]
                 kubernetes_api.delete_namespaced_deployment(
-                    name=image_name, namespace=deploy_conf["metadata"]["namespace"]
+                    name=image_name, namespace=(deploy_conf["metadata"]["namespace"])
                 )
                 logging.info(f"Successfully deleted '{image_name}'")
 
@@ -387,7 +390,7 @@ if __name__ == "__main__":
 
                 create_namespace(kubernetes_api, deploy_conf)
                 kubernetes_api.create_namespaced_deployment(
-                    body=deploy_conf, namespace=deploy_conf["metadata"]["namespace"]
+                    body=deploy_conf, namespace=(deploy_conf["metadata"]["namespace"])
                 )
 
                 logging.info(

--- a/build-service.py
+++ b/build-service.py
@@ -209,10 +209,7 @@ def create_namespace(kubernetes_api, deploy_conf):
             namespace_manifest = {
                 "apiVersion": "v1",
                 "kind": "Namespace",
-                "metadata": {
-                    "name": ns, 
-                    "resourceversion": "v1"
-                    },
+                "metadata": {"name": ns, "resourceversion": "v1"},
             }
             namespace_api.create(body=namespace_manifest)
             logging.debug(f"created a new namespace :{namespace_manifest}")
@@ -324,7 +321,9 @@ def restart_request(image_name):
         kubernetes_api = kubernetes.client.AppsV1Api()
         try:
             kubernetes_api.patch_namespaced_deployment(
-                name=image_name, namespace=deploy_conf["metadata"]["namespace"], body=deploy_conf
+                name=image_name,
+                namespace=deploy_conf["metadata"]["namespace"],
+                body=deploy_conf
             )
         except ApiException as e:
             logging.error(f"failed to restart: {e}")
@@ -369,7 +368,9 @@ if __name__ == "__main__":
             if args["--restart"]:
                 image_name = args["--restart"]
                 kubernetes_api.patch_namespaced_deployment(
-                    name=image_name, namespace=(deploy_conf["metadata"]["namespace"]), body=deploy_conf
+                    name=image_name,
+                    namespace=(deploy_conf["metadata"]["namespace"]),
+                    body=deploy_conf
                 )
                 logging.info(f"Successfully restarted '{image_name}'")
 

--- a/build-service.py
+++ b/build-service.py
@@ -39,7 +39,6 @@ from kubernetes.client.rest import ApiException
 
 from kubernetes import config, dynamic
 from kubernetes.client import api_client
-import time
 
 app = Flask(__name__)
 dclient = docker.from_env()
@@ -182,8 +181,10 @@ def build_repo(repo_dir, branch, deploy_conf, service_conf):
     return image_name
 
 # create a new namespace specified in the deployment script and the namespace is not already in the system.
-# otherwise, if not specified, use default as namespace 
-def create_namespace(kubernetes_api,deploy_conf):
+# otherwise, if not specified, use default as namespace
+
+
+def create_namespace(kubernetes_api, deploy_conf):
 
     if (not "namespace" in deploy_conf["metadata"]):
         # namespace is not specified in deplyoment config, just say the that namespace is default
@@ -192,14 +193,14 @@ def create_namespace(kubernetes_api,deploy_conf):
     elif (deploy_conf["metadata"]["namespace"] == "default"):
         # do nothing
         return
-    
+
     ns = deploy_conf["metadata"]["namespace"]
     try:
         namespaces = kubernetes_api.list_namespaced_deployment(ns)
         # logging.debug(namespaces.items)
         if (len(namespaces.items) > 0):
             logging.debug(f"deployments found for {ns}. Don't need to make namespace")
-        else: 
+        else:
             logging.debug(f"no deployments found for namespace, time to make another one")
             testclient = dynamic.DynamicClient(
                 api_client.ApiClient(configuration=config.load_kube_config())
@@ -214,7 +215,7 @@ def create_namespace(kubernetes_api,deploy_conf):
             logging.debug(f"created a new namespace :{namespace_manifest}")
     except Exception as e:
         logging.debug(f"no namespaces on the pi :{e}")
-        
+
 
 # POST /build: JSON API to start new build
 @app.route("/build", methods=["POST"])
@@ -257,7 +258,7 @@ def build_request():
         kubernetes.config.load_kube_config()
         kubernetes_api = kubernetes.client.AppsV1Api()
         try:
-            create_namespace(kubernetes_api,deploy_conf)
+            create_namespace(kubernetes_api, deploy_conf)
             kubernetes_api.create_namespaced_deployment(
                 body=deploy_conf, namespace=deploy_conf["metadata"]["namespace"]
             )
@@ -384,7 +385,7 @@ if __name__ == "__main__":
                     logging.error(f"Error building repo: {e}")
                     exit(1)
 
-                create_namespace(kubernetes_api,deploy_conf)
+                create_namespace(kubernetes_api, deploy_conf)
                 kubernetes_api.create_namespaced_deployment(
                     body=deploy_conf, namespace=deploy_conf["metadata"]["namespace"]
                 )

--- a/build-service.py
+++ b/build-service.py
@@ -203,7 +203,9 @@ def create_namespace(kubernetes_api, deploy_conf):
                 testclient = dynamic.DynamicClient(
                     api_client.ApiClient(configuration=config.load_kube_config())
                 )
-                namespace_api = testclient.resources.get(api_version="v1", kind="Namespace")
+                namespace_api = testclient.resources.get(
+                    api_version="v1", kind="Namespace"
+                )
                 namespace_manifest = {
                     "apiVersion": "v1",
                     "kind": "Namespace",

--- a/build-service.py
+++ b/build-service.py
@@ -186,7 +186,7 @@ def build_repo(repo_dir, branch, deploy_conf, service_conf):
 def create_namespace(kubernetes_api, deploy_conf):
 
     if "namespace" not in deploy_conf["metadata"]:
-        # namespace is not specified in deplyoment config, just say the that namespace is default
+        # namespace is not specified in deplyoment config, just set namespace as default
         deploy_conf["metadata"]["namespace"] = "default"
         return
     elif deploy_conf["metadata"]["namespace"] == "default":
@@ -196,26 +196,28 @@ def create_namespace(kubernetes_api, deploy_conf):
     ns = deploy_conf["metadata"]["namespace"]
     try:
         namespaces = kubernetes_api.list_namespaced_deployment(ns)
-        # logging.debug(namespaces.items)
         if len(namespaces.items) > 0:
             logging.debug(f"deployments found for {ns}. Don't need to make namespace")
         else:
-            logging.debug(
-                "no deployments found for namespace, time to make another one"
-            )
-            testclient = dynamic.DynamicClient(
-                api_client.ApiClient(configuration=config.load_kube_config())
-            )
-            namespace_api = testclient.resources.get(api_version="v1", kind="Namespace")
-            namespace_manifest = {
-                "apiVersion": "v1",
-                "kind": "Namespace",
-                "metadata": {"name": ns, "resourceversion": "v1"},
-            }
-            namespace_api.create(body=namespace_manifest)
-            logging.debug(f"created a new namespace :{namespace_manifest}")
+            try:
+                testclient = dynamic.DynamicClient(
+                    api_client.ApiClient(configuration=config.load_kube_config())
+                )
+                namespace_api = testclient.resources.get(api_version="v1", kind="Namespace")
+                namespace_manifest = {
+                    "apiVersion": "v1",
+                    "kind": "Namespace",
+                    "metadata": {"name": ns, "resourceversion": "v1"},
+                }
+                namespace_api.create(body=namespace_manifest)
+                logging.debug(f"created a new namespace :{namespace_manifest}")
+            except Exception as e:
+                logging.error(f"failed to create namespace: {e}")
+                return {"err": f"Failed to create namespace: {e}"}, 500
+
     except Exception as e:
-        logging.debug(f"no namespaces on the pi :{e}")
+        # try to get the deployments for the namespace
+        logging.debug(f"no deployments for namespace on the pi :{e}")
 
 
 # POST /build: JSON API to start new build


### PR DESCRIPTION
Can now specify a new custom namespace in the build service
if one is not specified in the deployment yaml, it will default to the `default` namespace

tested through CLI with command: `python3 build-service.py -vv https://github.com/capstone-kubernetes-aas/test-local-reg -b main`

Update `https://github.com/capstone-kubernetes-aas/test-local-reg/blob/main/kaas.deploy.yml` to the three cases for testing:
1. no namespace specified
2. default as namespace in the deployment yaml
3. custom namespace in the deployment yaml

You can check the namespaces by viewing the admin dashboard: https://dashboard.capstone.detjens.dev/#/login
and selecting the namespace you would like to view. 

![Screenshot 2022-04-18 111922](https://user-images.githubusercontent.com/29806316/163854992-affe9357-2dd3-4765-97a7-6cc0c87fadb3.png)

